### PR TITLE
Render superscript for ^*^

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -118,15 +118,15 @@ func init() {
 	RegisterCoreRule(400, ruleSmartQuotes)
 
 	RegisterBlockRule(100, ruleCode, nil)
-	RegisterBlockRule(200, ruleFence, []int{1100, 600, 300, 500})
-	RegisterBlockRule(300, ruleBlockQuote, []int{1100, 600, 500})
-	RegisterBlockRule(400, ruleHR, []int{1100, 600, 300, 500})
-	RegisterBlockRule(500, ruleList, []int{1100, 600, 300})
+	RegisterBlockRule(200, ruleFence, []int{1100, 600, 300, 500, 1200})
+	RegisterBlockRule(300, ruleBlockQuote, []int{1100, 600, 500, 1200})
+	RegisterBlockRule(400, ruleHR, []int{1100, 600, 300, 500, 1200})
+	RegisterBlockRule(500, ruleList, []int{1100, 600, 300, 1200})
 	RegisterBlockRule(600, ruleReference, nil)
-	RegisterBlockRule(700, ruleHeading, []int{1100, 600, 300})
+	RegisterBlockRule(700, ruleHeading, []int{1100, 600, 300, 1200})
 	RegisterBlockRule(800, ruleLHeading, nil)
-	RegisterBlockRule(900, ruleHTMLBlock, []int{1100, 600, 300})
-	RegisterBlockRule(1000, ruleTable, []int{1100, 600})
+	RegisterBlockRule(900, ruleHTMLBlock, []int{1100, 600, 300, 1200})
+	RegisterBlockRule(1000, ruleTable, []int{1100, 600, 1200})
 	RegisterBlockRule(1100, ruleParagraph, nil)
 
 	RegisterInlineRule(100, ruleText)
@@ -140,4 +140,5 @@ func init() {
 	RegisterInlineRule(900, ruleAutolink)
 	RegisterInlineRule(1000, ruleHTMLInline)
 	RegisterInlineRule(1100, ruleEntity)
+	RegisterInlineRule(1200, ruleSupScript)
 }

--- a/render.go
+++ b/render.go
@@ -214,6 +214,12 @@ func (r *Renderer) renderToken(tokens []Token, idx int, options RenderOptions) {
 	case *StrongOpen:
 		r.w.WriteString("<strong>")
 
+	case *SupScriptClose:
+		r.w.WriteString("</sup>")
+
+	case *SupScriptOpen:
+		r.w.WriteString("<sup>")
+
 	case *StrikethroughClose:
 		r.w.WriteString("</s>")
 

--- a/supscript.go
+++ b/supscript.go
@@ -1,0 +1,139 @@
+// Copyright 2017 James.gx_Chen@htc.com All rights reserved.
+
+package markdown
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+func scanSupScript(s *StateInline, start int) (canOpen bool, canClose bool, count int) {
+	pos := start
+	max := s.PosMax
+	src := s.Src
+	marker := src[start]
+
+	lastChar, lastLen := utf8.DecodeLastRuneInString(src[:start])
+
+	for pos < max && src[pos] == marker {
+		pos++
+	}
+	count = pos - start
+
+	nextChar, nextLen := utf8.DecodeRuneInString(src[pos:])
+
+	isLastSpaceOrStart := lastLen == 0 || unicode.IsSpace(lastChar)
+	isNextSpaceOrEnd := nextLen == 0 || unicode.IsSpace(nextChar)
+	isLastPunct := !isLastSpaceOrStart && (isMarkdownPunct(lastChar) || unicode.IsPunct(lastChar))
+	isNextPunct := !isNextSpaceOrEnd && (isMarkdownPunct(nextChar) || unicode.IsPunct(nextChar))
+
+	leftFlanking := !isNextSpaceOrEnd && (!isNextPunct || isLastSpaceOrStart || isLastPunct)
+	rightFlanking := !isLastSpaceOrStart && (!isLastPunct || isNextSpaceOrEnd || isNextPunct)
+
+	canOpen = leftFlanking
+	canClose = rightFlanking
+
+	return
+}
+
+var sup [256]bool
+
+func init() {
+	sup['^'] = true
+}
+
+func ruleSupScript(s *StateInline, silent bool) (_ bool) {
+	src := s.Src
+	max := s.PosMax
+	start := s.Pos
+	marker := src[start]
+
+	if !sup[marker] {
+		return
+	}
+
+	if silent {
+		return
+	}
+
+	canOpen, _, startCount := scanSupScript(s, start)
+	s.Pos += startCount
+	if !canOpen {
+		s.Pending.WriteString(src[start:s.Pos])
+		return true
+	}
+
+	stack := []int{startCount}
+	found := false
+
+	for s.Pos < max {
+		if src[s.Pos] == marker {
+			canOpen, canClose, count := scanSupScript(s, s.Pos)
+
+			if canClose {
+				oldCount := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				newCount := count
+
+				for oldCount != newCount {
+					if newCount < oldCount {
+						stack = append(stack, oldCount-newCount)
+						break
+					}
+
+					newCount -= oldCount
+
+					if len(stack) == 0 {
+						break
+					}
+
+					s.Pos += oldCount
+					oldCount = stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+				}
+
+				if len(stack) == 0 {
+					startCount = oldCount
+					found = true
+					break
+				}
+
+				s.Pos += count
+				continue
+			}
+
+			if canOpen {
+				stack = append(stack, count)
+			}
+
+			s.Pos += count
+			continue
+		}
+
+		s.Md.Inline.SkipToken(s)
+	}
+
+	if !found {
+		s.Pos = start
+		return
+	}
+
+	s.PosMax = s.Pos
+	s.Pos = start + startCount
+
+	count := startCount
+	if count > 0 {
+		s.PushOpeningToken(&SupScriptOpen{})
+	}
+
+	s.Md.Inline.Tokenize(s)
+
+	if count%2 != 0 {
+		s.PushClosingToken(&SupScriptClose{})
+	}
+
+	s.Pos = s.PosMax + startCount
+	s.PosMax = max
+
+	return true
+}

--- a/token.go
+++ b/token.go
@@ -77,6 +77,14 @@ type StrongClose struct {
 	Lvl int
 }
 
+type SupScriptOpen struct {
+	Lvl int
+}
+
+type SupScriptClose struct {
+	Lvl int
+}
+
 type StrikethroughOpen struct {
 	Lvl int
 }
@@ -262,6 +270,10 @@ func (t *StrongOpen) Level() int { return t.Lvl }
 
 func (t *StrongClose) Level() int { return t.Lvl }
 
+func (t *SupScriptOpen) Level() int { return t.Lvl }
+
+func (t *SupScriptClose) Level() int { return t.Lvl }
+
 func (t *StrikethroughOpen) Level() int { return t.Lvl }
 
 func (t *StrikethroughClose) Level() int { return t.Lvl }
@@ -347,6 +359,10 @@ func (t *EmphasisClose) SetLevel(lvl int) { t.Lvl = lvl }
 func (t *StrongOpen) SetLevel(lvl int) { t.Lvl = lvl }
 
 func (t *StrongClose) SetLevel(lvl int) { t.Lvl = lvl }
+
+func (t *SupScriptOpen) SetLevel(lvl int) { t.Lvl = lvl }
+
+func (t *SupScriptClose) SetLevel(lvl int) { t.Lvl = lvl }
 
 func (t *StrikethroughOpen) SetLevel(lvl int) { t.Lvl = lvl }
 
@@ -434,6 +450,10 @@ func (t *StrongOpen) Opening() bool { return true }
 
 func (t *StrongClose) Opening() bool { return false }
 
+func (t *SupScriptOpen) Opening() bool { return true }
+
+func (t *SupScriptClose) Opening() bool { return false }
+
 func (t *StrikethroughOpen) Opening() bool { return true }
 
 func (t *StrikethroughClose) Opening() bool { return false }
@@ -519,6 +539,10 @@ func (t *EmphasisClose) Closing() bool { return true }
 func (t *StrongOpen) Closing() bool { return false }
 
 func (t *StrongClose) Closing() bool { return true }
+
+func (t *SupScriptOpen) Closing() bool { return false }
+
+func (t *SupScriptClose) Closing() bool { return true }
 
 func (t *StrikethroughOpen) Closing() bool { return false }
 
@@ -606,6 +630,10 @@ func (t *StrongOpen) Block() bool { return false }
 
 func (t *StrongClose) Block() bool { return false }
 
+func (t *SupScriptOpen) Block() bool { return false }
+
+func (t *SupScriptClose) Block() bool { return false }
+
 func (t *StrikethroughOpen) Block() bool { return false }
 
 func (t *StrikethroughClose) Block() bool { return false }
@@ -691,6 +719,10 @@ func (t *EmphasisClose) Tag() string { return "em" }
 func (t *StrongOpen) Tag() string { return "strong" }
 
 func (t *StrongClose) Tag() string { return "strong" }
+
+func (t *SupScriptOpen) Tag() string { return "sup" }
+
+func (t *SupScriptClose) Tag() string { return "sup" }
 
 func (t *StrikethroughOpen) Tag() string { return "s" }
 


### PR DESCRIPTION
Since this markdown parser cannot parse superscript and there are extensions elsewhere, I add a rule for superscript.

subscript use ~*~ but it conflicts with other rule.