### PR TITLE
options.Quote: iterate over []rune to get the index right

### DIFF
--- a/options.go
+++ b/options.go
@@ -26,7 +26,7 @@ func Typographer(b bool) option {
 
 func Quotes(s string) option {
 	return func(m *Markdown) {
-		for i, r := range s {
+		for i, r := range []rune(s) {
 			m.Quotes[i] = r
 		}
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,13 @@
+package markdown
+
+import (
+	"testing"
+)
+
+func TestQuote(t *testing.T) {
+	quotes := "‘’“”"
+	md := New(Quotes(quotes))
+	if string(md.Quotes[:]) != quotes {
+		t.Errorf("expected %q, got %q", quotes, md.Quotes)
+	}
+}


### PR DESCRIPTION
Fixes issue #3.

When go iterates over a string, the index is the position in bytes,
which is not the index into the array of runes in the general case.